### PR TITLE
Favorites Drawer

### DIFF
--- a/src/components/FavoritesDrawer.js
+++ b/src/components/FavoritesDrawer.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  useDisclosure,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerOverlay,
+  DrawerHeader,
+  DrawerContent,
+  DrawerFooter,
+  Button,
+  Box,
+  Text
+} from '@chakra-ui/core';
+import { LaunchItem } from './launches';
+import { LaunchPadItem } from './launch-pads';
+import { useContext } from 'react';
+import FavoritesContext from '../store/favorites-context';
+
+function FavoritesDrawer() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const btnRef = React.useRef();
+  const favoritesContext = useContext(FavoritesContext);
+  const hasLaunchItems = favoritesContext.launchItems.length > 0;
+  const hasLaunchPadItems = favoritesContext.launchPadItems.length > 0;
+  return (
+    <>
+      <Button ref={btnRef} colorScheme="teal" onClick={onOpen}>
+        Favorites
+      </Button>
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose} finalFocusRef={btnRef}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>Favorites</DrawerHeader>
+
+          <DrawerBody overflow="scroll">
+            {hasLaunchItems && (
+              <Box>
+                <Text fontSize="lg">Favorite Launches</Text>
+                {favoritesContext.launchItems.flat().map(launch => (
+                  <LaunchItem launch={launch} key={launch.flight_number} display="drawer" />
+                ))}
+              </Box>
+            )}
+            {hasLaunchPadItems && (
+              <Box>
+                <Text fontSize="lg">Favorite Launch Pads</Text>
+                {favoritesContext.launchPadItems.flat().map(launchPad => (
+                  <LaunchPadItem launchPad={launchPad} key={launchPad.site_id} />
+                ))}
+              </Box>
+            )}
+
+            {!hasLaunchItems && !hasLaunchPadItems && (
+              <Text fontSize="lg">Oops, nothing here. Guess it's time to go and favorite something</Text>
+            )}
+          </DrawerBody>
+
+          <DrawerFooter>
+            <Button variant="outline" mr={3} onClick={onClose}>
+              Close
+            </Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}
+
+export default FavoritesDrawer;

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -7,18 +7,22 @@ import Launch from "./launch";
 import Home from "./home";
 import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
+import FavoritesProvider from "../store/FavoritesProvider";
+import FavoritesDrawer from "./FavoritesDrawer";
 
 export default function App() {
   return (
     <div>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/launches" element={<Launches />} />
-        <Route path="/launches/:launchId" element={<Launch />} />
-        <Route path="/launch-pads" element={<LaunchPads />} />
-        <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
-      </Routes>
+      <FavoritesProvider>
+        <NavBar />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/launches" element={<Launches />} />
+          <Route path="/launches/:launchId" element={<Launch />} />
+          <Route path="/launch-pads" element={<LaunchPads />} />
+          <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
+        </Routes>
+      </FavoritesProvider>
     </div>
   );
 }
@@ -42,6 +46,7 @@ function NavBar() {
       >
         ¡SPACE·R0CKETS!
       </Text>
+      <FavoritesDrawer/>
     </Flex>
   );
 }

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useParams } from "react-router-dom";
-import { MapPin, Navigation } from "react-feather";
+import { MapPin, Navigation, Star } from "react-feather";
 import {
   Flex,
   Heading,
@@ -21,6 +21,7 @@ import { useSpaceX } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import { LaunchItem } from "./launches";
+import FavoritesContext from "../store/favorites-context";
 
 export default function LaunchPad() {
   let { launchPadId } = useParams();
@@ -68,6 +69,15 @@ const randomColor = (start = 200, end = 250) =>
   `hsl(${start + end * Math.random()}, 80%, 90%)`;
 
 function Header({ launchPad }) {
+  const favoritesContext = useContext(FavoritesContext);
+  const isFavorite = favoritesContext.launchPadItems.some(item => item.site_id === launchPad.site_id);
+  const onLaunchPadClickHandler = launchPad => {
+    if (isFavorite) {
+      favoritesContext.removeLaunchPadItem(launchPad.site_id);
+    } else {
+      favoritesContext.addLaunchPadItem(launchPad);
+    }
+  };
   return (
     <Flex
       background={`linear-gradient(${randomColor()}, ${randomColor()})`}
@@ -105,6 +115,7 @@ function Header({ launchPad }) {
             Retired
           </Badge>
         )}
+        <Star onClick={() => onLaunchPadClickHandler(launchPad)} color='red' fill={isFavorite ? 'red' : 'transparent'}/>
       </Stack>
     </Flex>
   );

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Badge, Box, SimpleGrid, Text } from "@chakra-ui/core";
 import { Link } from "react-router-dom";
 
@@ -6,6 +6,8 @@ import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
 import { useSpaceXPaginated } from "../utils/use-space-x";
+import FavoritesContext from "../store/favorites-context";
+import { Star } from "react-feather";
 
 const PAGE_SIZE = 12;
 
@@ -41,18 +43,30 @@ export default function LaunchPads() {
   );
 }
 
-function LaunchPadItem({ launchPad }) {
+export function LaunchPadItem({ launchPad }) {
+  const favoritesContext = useContext(FavoritesContext);
+  const isFavorite = favoritesContext.launchPadItems.some(item => item.site_id === launchPad.site_id);
+  const onLaunchPadClickHandler = () => {
+    if (isFavorite) {
+      favoritesContext.removeLaunchPadItem(launchPad.site_id);
+    } else {
+      favoritesContext.addLaunchPadItem(launchPad);
+    }
+  };
   return (
     <Box
-      as={Link}
-      to={`/launch-pads/${launchPad.site_id}`}
       boxShadow="md"
       borderWidth="1px"
       rounded="lg"
       overflow="hidden"
       position="relative"
+      d="flex"
+      justifyContent="space-between"
+      alignItems="center"
     >
-      <Box p="6">
+      <Box 
+        p="6" as={Link}
+        to={`/launch-pads/${launchPad.site_id}`}>
         <Box d="flex" alignItems="baseline">
           {launchPad.status === "active" ? (
             <Badge px="2" variant="solid" variantColor="green">
@@ -89,6 +103,7 @@ function LaunchPadItem({ launchPad }) {
           {launchPad.vehicles_launched.join(", ")}
         </Text>
       </Box>
+      <Star cursor="pointer" onClick={onLaunchPadClickHandler} color="red" fill={isFavorite ? 'red' : 'transparent'} />
     </Box>
   );
 }

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useParams, Link as RouterLink } from "react-router-dom";
 import { format as timeAgo } from "timeago.js";
-import { Watch, MapPin, Navigation, Layers } from "react-feather";
+import { Watch, MapPin, Navigation, Layers, Star } from "react-feather";
 import {
   Flex,
   Heading,
@@ -25,6 +25,7 @@ import { useSpaceX } from "../utils/use-space-x";
 import { formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import FavoritesContext from "../store/favorites-context";
 
 export default function Launch() {
   let { launchId } = useParams();
@@ -63,6 +64,15 @@ export default function Launch() {
 }
 
 function Header({ launch }) {
+  const favoritesContext = useContext(FavoritesContext);
+  const isFavorite = favoritesContext.launchItems.some(item => item.flight_number === launch.flight_number);
+  const onLaunchClickHandler = launch => {
+    if(isFavorite) {
+      favoritesContext.removeLaunchItem(launch.flight_number);
+    } else {
+      favoritesContext.addLaunchItem(launch);
+    }
+  };
   return (
     <Flex
       bgImage={`url(${launch.links.flickr_images[0]})`}
@@ -108,6 +118,7 @@ function Header({ launch }) {
             Failed
           </Badge>
         )}
+        <Star onClick={() => onLaunchClickHandler(launch)} color='red' fill={isFavorite ? 'red' : 'transparent'}/>
       </Stack>
     </Flex>
   );

--- a/src/store/FavoritesProvider.js
+++ b/src/store/FavoritesProvider.js
@@ -1,0 +1,71 @@
+import React, { useReducer } from 'react';
+import FavoritesContext from './favorites-context';
+
+const defaultFavoriteState = {
+  launchItems: [],
+  launchPadItems: []
+};
+
+const favoritesReducer = (state, action) => {
+  let updatedItems;
+  let existingItemIndex;
+  let existingItem;
+  switch (action.type) {
+    case 'ADD_LAUNCH_ITEM':
+      existingItemIndex = state.launchItems.findIndex(item => item.flight_number === action.item.flight_number);
+      existingItem = state.launchItems[existingItemIndex];
+      if (existingItem || existingItemIndex !== -1) {
+        updatedItems = [...state.launchItems];
+      } else {
+        updatedItems = [...state.launchItems, action.item];
+      }
+      return { launchItems: updatedItems, launchPadItems: state.launchPadItems };
+    case 'REMOVE_LAUNCH_ITEM': {
+      updatedItems = state.launchItems.filter(item => item.flight_number !== action.id);
+      return { launchItems: updatedItems, launchPadItems: state.launchPadItems };
+    }
+    case 'ADD_LAUNCH_PAD_ITEM':
+      existingItemIndex = state.launchPadItems.findIndex(item => item.site_id === action.item.site_id);
+      existingItem = state.launchPadItems[existingItemIndex];
+      if (existingItem) {
+        updatedItems = [...state.launchPadItems];
+      } else {
+        updatedItems = [...state.launchPadItems, action.item];
+      }
+
+      return { launchPadItems: updatedItems, launchItems: state.launchItems };
+    case 'REMOVE_LAUNCH_PAD_ITEM': {
+      updatedItems = state.launchPadItems.filter(item => item.site_id !== action.id);
+      return { launchPadItems: updatedItems, launchItems: state.launchItems };
+    }
+    default:
+      return state;
+  }
+};
+
+const FavoritesProvider = ({ children }) => {
+  const [favoritesState, dispatchFavoritesAction] = useReducer(favoritesReducer, defaultFavoriteState);
+  const addLaunchItemHandler = item => {
+    dispatchFavoritesAction({ type: 'ADD_LAUNCH_ITEM', item });
+  };
+  const removeLaunchItemHandler = id => {
+    dispatchFavoritesAction({ type: 'REMOVE_LAUNCH_ITEM', id });
+  };
+  const addLaunchPadItemHandler = item => {
+    dispatchFavoritesAction({ type: 'ADD_LAUNCH_PAD_ITEM', item });
+  };
+  const removeLaunchPadItemHandler = id => {
+    dispatchFavoritesAction({ type: 'REMOVE_LAUNCH_PAD_ITEM', id });
+  };
+  const favoritesContext = {
+    launchItems: favoritesState.launchItems,
+    launchPadItems: favoritesState.launchPadItems,
+    addLaunchItem: addLaunchItemHandler,
+    removeLaunchItem: removeLaunchItemHandler,
+    addLaunchPadItem: addLaunchPadItemHandler,
+    removeLaunchPadItem: removeLaunchPadItemHandler
+  };
+  return <FavoritesContext.Provider value={favoritesContext}>{children}</FavoritesContext.Provider>;
+};
+
+export default FavoritesProvider;

--- a/src/store/favorites-context.js
+++ b/src/store/favorites-context.js
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+const FavoritesContext = createContext({
+  launchItems: [],
+  addLaunchItem: item => {},
+  removeLaunchItem: id => {},
+  launchPadItems: [],
+  addLaunchPadItem: item => {},
+  removeLaunchPadItem: id => {}
+});
+
+export default FavoritesContext;


### PR DESCRIPTION
**NOTE**: At the time of writing this, SpaceX API V3 had technical difficulties

The purpose of this PR is to add a new feature "Favorites drawer".  
User should be able to save and persist Favorite data across the sessions

List of requirements:

- [x] [a user can mark - "star" - launches or launch pads as favorites - both from the list and details page for all items](#fav-star)
- [x] [a list of favorites is available as a slide-in drawer](#fav-drawer)
- [x] [from the list, the user can navigate to the favorite items](#fav-nav)
- [x] [the user is able to remove items from the list (from within the list and on the details page of an item that is currently in the list)](#fav-clear)
- [ ] [the list is persisted after the app is closed (but everything is stored locally for now)](#fav-save)

All functionality is tied into a store implemented with [React Context API](https://reactjs.org/docs/context.html)
Context was chosen as the simplest way to provide data across the app
Other considered options:

- Internal state and prop drilling | Considered too cumbersome and not very scalable in the future
- [Redux with RTK](https://redux-toolkit.js.org/) | This is my standard approach but for this use case seemed like overkill

### <a name="fav-star"> Marking favorite item

Added a <Star /> icon from `react-feater` library to LaunchItem and LaunchPadItem templates.
Templates themselves were modified to reduce Link clickable area to allow favourite button functionality to work.
Clicking the star, an item would be added to either `launchItems` or `launchPadItems` array depending on the item.

### <a name="fav-drawer"> Slide-in Drawer

Added a Drawer component from [`Chakra UI` library](https://chakra-ui.com/docs/overlay/drawer)
Displays the 2 lists `launchItems` and `launchPadItems`  depending on existing items inside.

### <a name="fav-nav"> List navigation

Navigation is inherited with LaunchItem and LaunchPadItem templates. 
Templates were modified accordingly to not alter the navigation logic.

### <a name="fav-clear"> Remove favorite items

Star click event handlers would check if the item is favorited or not and dispatch appropriate action.

### <a name="fav-save"> Persist data between sessions

Not implemented. Due to technical difficulties on the APIs side and time constraints.
Possible solution approaches:

- Store favorites arrays in `localStorage` | Possible concern: Data can be stored only as a String, will require conversion back on forth to set the data.
- Store favorites arrays in `IndexedDB` | Allows to store data with key-value pairs and can store multiple data types like objects. 
I'd pick this approach as storing/fetching data logic can be easily integrated

---

<details>
<summary>List of changes to date</summary>

---

- Create default context for Favorite Items
- Create FavoritesProvider with context logic
- Create FavoritesDrawer component for item view
- Provide context to the app Add FavoritesDrawer to DOM
- Add logic to use context for launch items
- Add logic to use context for launch items in list
- Add logic to use context for launch pads
- Add logic to use context for launch pads in list

--- 

</details>
