### PR TITLE
Fix launch date display

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatDateTimeLocal } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import FavoritesContext from "../store/favorites-context";
@@ -135,7 +136,7 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip label={formatDateTimeLocal(launch.launch_date_local)}>{formatDateTime(launch.launch_date_utc)}</Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -15,6 +15,19 @@ export function formatDateTime(timestamp) {
     hour: "numeric",
     minute: "numeric",
     second: "numeric",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  }).format(new Date(timestamp));
+}
+
+export function formatDateTimeLocal(timestamp) {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }


### PR DESCRIPTION
**NOTE**: At the time of writing this, SpaceX API V3 had technical difficulties

The purpose of this PR is to fix a bug in how launch date time string is displayed.
Launch datetime on the launch details page should displayed in the timezone of launch site.

List of requirements:

- [ ] [Display datetime of location](#datetime)
- [x] [Display tooltip with local date time of users app](#tooltip)

Have to admit that my brain almost broke here. 
Not sure why but I just could not process the requirement.
Instead of showing the datetime in time zone of the launch site, fallback is set to display datetime in timezone of Universal Time Coordinated (UTC)

### <a name="datetime"> Display date time of location

Default date is set to display datetime in UTC

### <a name="tooltip"> Display tooltip with local date time of users app

Hovering on the Tooltip will display datetime in timezone of the local user

---

<details>
<summary>List of changes to date</summary>

---

- Add separate formatDateTime function to display local timezone Modify existing formatDateTime to always print dateTime in UTC timezone
- Use Tooltip to display default UTC and local dateTime

--- 

</details>
